### PR TITLE
chore(provider): scope variables to current element

### DIFF
--- a/lib/variableProvider/ExampleJsonProvider.js
+++ b/lib/variableProvider/ExampleJsonProvider.js
@@ -13,7 +13,16 @@ export class ExampleJsonProvider extends VariableProvider {
     }
 
     const parsedData = getVariablesFromString(data);
-    return parsedData;
+
+    // Scope data to current element only
+    const result = parsedData.map(variable => {
+      return {
+        ...variable,
+        scope: element
+      };
+    });
+
+    return result;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@bpmn-io/element-template-chooser": "^1.0.0",
         "@bpmn-io/properties-panel": "^1.8.0",
-        "@bpmn-io/variable-resolver": "^0.1.0",
+        "@bpmn-io/variable-resolver": "^0.1.3",
         "@testing-library/preact": "^3.2.3",
         "camunda-bpmn-js-behaviors": "^0.5.0",
         "chai": "^4.3.7",
@@ -404,7 +404,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.8.0.tgz",
       "integrity": "sha512-yAS7ZYX+D56K+luC36u96eRMLb4VHcPUwTUqMZ/Z/Je2gou2DJLRbuBTHAB4jjKt4wFCHSG4B8Y+TrBciEYf4w==",
-      "peer": true,
       "dependencies": {
         "min-dash": "^4.0.0"
       }
@@ -451,27 +450,18 @@
       }
     },
     "node_modules/@bpmn-io/variable-resolver": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/variable-resolver/-/variable-resolver-0.1.0.tgz",
-      "integrity": "sha512-rLM8wPYjjL+nWatS8zRDKDRcC7VAVugmwLT6DGq8EhbW1OaTe4utzKBYk7r16cVCvOSZX7/MXNGoJQdThQXfVQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/variable-resolver/-/variable-resolver-0.1.3.tgz",
+      "integrity": "sha512-BZtb6CfA0WZcN/pA/SrLk7S/m7cYqXxhAGHKCU4mwU+SE8eAzt1HLO522nApR8jmEkzmBZVYqzxVnAMITAHNLA==",
       "dev": true,
       "dependencies": {
-        "@bpmn-io/extract-process-variables": "^0.7.0",
+        "@bpmn-io/extract-process-variables": "^0.8.0",
         "@lezer/common": "^1.0.2",
-        "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format",
+        "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format-build",
         "min-dash": "^4.0.0"
       },
       "peerDependencies": {
         "bpmn-js": "*"
-      }
-    },
-    "node_modules/@bpmn-io/variable-resolver/node_modules/@bpmn-io/extract-process-variables": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.7.0.tgz",
-      "integrity": "sha512-NJcL+l5I9OY9wPD9MTfU8Slbfo/5gWYgooE0nGDVAlj6q2q4ge5sW0u6U1CoXE7YGVvn5oDcdXrgukhOQs2XWg==",
-      "dev": true,
-      "dependencies": {
-        "min-dash": "^4.0.0"
       }
     },
     "node_modules/@bpmn-io/variable-resolver/node_modules/lezer-feel": {
@@ -7804,7 +7794,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.8.0.tgz",
       "integrity": "sha512-yAS7ZYX+D56K+luC36u96eRMLb4VHcPUwTUqMZ/Z/Je2gou2DJLRbuBTHAB4jjKt4wFCHSG4B8Y+TrBciEYf4w==",
-      "peer": true,
       "requires": {
         "min-dash": "^4.0.0"
       }
@@ -7851,30 +7840,21 @@
       }
     },
     "@bpmn-io/variable-resolver": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/variable-resolver/-/variable-resolver-0.1.0.tgz",
-      "integrity": "sha512-rLM8wPYjjL+nWatS8zRDKDRcC7VAVugmwLT6DGq8EhbW1OaTe4utzKBYk7r16cVCvOSZX7/MXNGoJQdThQXfVQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/variable-resolver/-/variable-resolver-0.1.3.tgz",
+      "integrity": "sha512-BZtb6CfA0WZcN/pA/SrLk7S/m7cYqXxhAGHKCU4mwU+SE8eAzt1HLO522nApR8jmEkzmBZVYqzxVnAMITAHNLA==",
       "dev": true,
       "requires": {
-        "@bpmn-io/extract-process-variables": "^0.7.0",
+        "@bpmn-io/extract-process-variables": "^0.8.0",
         "@lezer/common": "^1.0.2",
-        "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format",
+        "lezer-feel": "github:marstamm/lezer-feel#decouple-context-format-build",
         "min-dash": "^4.0.0"
       },
       "dependencies": {
-        "@bpmn-io/extract-process-variables": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.7.0.tgz",
-          "integrity": "sha512-NJcL+l5I9OY9wPD9MTfU8Slbfo/5gWYgooE0nGDVAlj6q2q4ge5sW0u6U1CoXE7YGVvn5oDcdXrgukhOQs2XWg==",
-          "dev": true,
-          "requires": {
-            "min-dash": "^4.0.0"
-          }
-        },
         "lezer-feel": {
           "version": "git+ssh://git@github.com/marstamm/lezer-feel.git#26fefead81b1dfb6a1550f739d748bb664d6ab39",
           "dev": true,
-          "from": "lezer-feel@github:marstamm/lezer-feel#decouple-context-format",
+          "from": "lezer-feel@github:marstamm/lezer-feel#decouple-context-format-build",
           "requires": {
             "@lezer/highlight": "^1.1.2",
             "@lezer/lr": "^1.2.5"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@bpmn-io/element-template-chooser": "^1.0.0",
     "@bpmn-io/properties-panel": "^1.8.0",
-    "@bpmn-io/variable-resolver": "^0.1.0",
+    "@bpmn-io/variable-resolver": "^0.1.3",
     "@testing-library/preact": "^3.2.3",
     "camunda-bpmn-js-behaviors": "^0.5.0",
     "chai": "^4.3.7",

--- a/test/fixtures/connectors.json
+++ b/test/fixtures/connectors.json
@@ -1,0 +1,776 @@
+[
+    {
+      "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+      "name": "REST Connector (No Auth)",
+      "id": "io.camunda.connectors.HttpJson.v1.noAuth",
+      "description": "Invoke REST API and retrieve the result",
+      "icon": {
+        "contents": "data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M17.0335%208.99997C17.0335%2013.4475%2013.4281%2017.0529%208.98065%2017.0529C4.53316%2017.0529%200.927765%2013.4475%200.927765%208.99997C0.927765%204.55248%204.53316%200.947083%208.98065%200.947083C13.4281%200.947083%2017.0335%204.55248%2017.0335%208.99997Z%22%20fill%3D%22%23505562%22%2F%3E%0A%3Cpath%20d%3D%22M4.93126%2014.1571L6.78106%203.71471H10.1375C11.1917%203.71471%2011.9824%203.98323%2012.5095%204.52027C13.0465%205.04736%2013.315%205.73358%2013.315%206.57892C13.315%207.44414%2013.0714%208.15522%2012.5841%208.71215C12.1067%209.25913%2011.4553%209.63705%2010.6298%209.8459L12.0619%2014.1571H10.3315L9.03364%2010.0249H7.24351L6.51254%2014.1571H4.93126ZM7.49711%208.59281H9.24248C9.99832%208.59281%2010.5901%208.42374%2011.0177%208.08561C11.4553%207.73753%2011.6741%207.26513%2011.6741%206.66842C11.6741%206.19106%2011.5249%205.81811%2011.2265%205.54959C10.9282%205.27113%2010.4558%205.1319%209.80936%205.1319H8.10874L7.49711%208.59281Z%22%20fill%3D%22white%22%2F%3E%0A%3C%2Fsvg%3E%0A"
+      },
+      "documentationRef": "https://docs.camunda.io/docs/components/modeler/web-modeler/connectors/available-connectors/rest/",
+      "appliesTo": [
+        "bpmn:Task"
+      ],
+      "category": {
+        "id": "rest",
+        "name": "REST Connector"
+      },
+      "elementType": {
+        "value": "bpmn:ServiceTask"
+      },
+      "groups": [
+        {
+          "id": "endpoint",
+          "label": "HTTP Endpoint"
+        },
+        {
+          "id": "input",
+          "label": "Payload"
+        },
+        {
+          "id": "output",
+          "label": "Response Mapping"
+        }
+      ],
+      "properties": [
+        {
+          "type": "Hidden",
+          "value": "io.camunda:http-json:1",
+          "binding": {
+            "type": "zeebe:taskDefinition:type"
+          }
+        },
+        {
+          "label": "Method",
+          "group": "endpoint",
+          "type": "Dropdown",
+          "value": "get",
+          "choices": [
+            { "name": "GET", "value": "get" },
+            { "name": "POST", "value": "post" },
+            { "name": "PATCH", "value": "patch" },
+            { "name": "PUT", "value": "put" },
+            { "name": "DELETE", "value": "delete" }
+          ],
+          "binding": {
+            "type": "zeebe:input",
+            "name": "method"
+          }
+        },
+        {
+          "label": "URL",
+          "group": "endpoint",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "url"
+          },
+          "constraints": {
+            "notEmpty": true,
+            "pattern": {
+              "value": "^https?://.*",
+              "message": "Must be a http(s) URL."
+            }
+          }
+        },
+        {
+          "label": "Query Parameters",
+          "description": "Map of query parameters to add to the request URL",
+          "group": "endpoint",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "queryParameters"
+          },
+          "optional": true
+        },
+        {
+          "label": "HTTP Headers",
+          "description": "Map of HTTP headers to add to the request",
+          "group": "endpoint",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "headers"
+          },
+          "optional": true
+        },
+        {
+          "label": "Request Body",
+          "description": "JSON payload to send with the request",
+          "group": "input",
+          "type": "Text",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "body"
+          },
+          "optional": true
+        },
+        {
+          "label": "Result Variable",
+          "description": "Name of variable to store the response in",
+          "group": "output",
+          "type": "String",
+          "binding": {
+            "type": "zeebe:taskHeader",
+            "key": "resultVariable"
+          }
+        },
+        {
+          "label": "Result Expression",
+          "description": "Expression to map the response into process variables",
+          "group": "output",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:taskHeader",
+            "key": "resultExpression"
+          }
+        }
+      ]
+    },
+    {
+      "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+      "name": "REST Connector (Basic Auth)",
+      "id": "io.camunda.connectors.HttpJson.v1.basicAuth",
+      "description": "Invoke REST API and retrieve the result secured by Basic Authentication",
+      "documentationRef": "https://docs.camunda.io/docs/components/modeler/web-modeler/connectors/available-connectors/rest/",
+      "icon": {
+        "contents": "data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M17.0335%208.99997C17.0335%2013.4475%2013.4281%2017.0529%208.98065%2017.0529C4.53316%2017.0529%200.927765%2013.4475%200.927765%208.99997C0.927765%204.55248%204.53316%200.947083%208.98065%200.947083C13.4281%200.947083%2017.0335%204.55248%2017.0335%208.99997Z%22%20fill%3D%22%23505562%22%2F%3E%0A%3Cpath%20d%3D%22M4.93126%2014.1571L6.78106%203.71471H10.1375C11.1917%203.71471%2011.9824%203.98323%2012.5095%204.52027C13.0465%205.04736%2013.315%205.73358%2013.315%206.57892C13.315%207.44414%2013.0714%208.15522%2012.5841%208.71215C12.1067%209.25913%2011.4553%209.63705%2010.6298%209.8459L12.0619%2014.1571H10.3315L9.03364%2010.0249H7.24351L6.51254%2014.1571H4.93126ZM7.49711%208.59281H9.24248C9.99832%208.59281%2010.5901%208.42374%2011.0177%208.08561C11.4553%207.73753%2011.6741%207.26513%2011.6741%206.66842C11.6741%206.19106%2011.5249%205.81811%2011.2265%205.54959C10.9282%205.27113%2010.4558%205.1319%209.80936%205.1319H8.10874L7.49711%208.59281Z%22%20fill%3D%22white%22%2F%3E%0A%3C%2Fsvg%3E%0A"
+      },
+      "appliesTo": [
+        "bpmn:Task"
+      ],
+      "elementType": {
+        "value": "bpmn:ServiceTask"
+      },
+      "category": {
+        "id": "rest",
+        "name": "REST Connector"
+      },
+      "groups": [
+        {
+          "id": "endpoint",
+          "label": "HTTP Endpoint"
+        },
+        {
+          "id": "input",
+          "label": "Payload"
+        },
+        {
+          "id": "authentication",
+          "label": "Authentication"
+        },
+        {
+          "id": "output",
+          "label": "Response Mapping"
+        }
+      ],
+      "properties": [
+        {
+          "type": "Hidden",
+          "value": "io.camunda:http-json:1",
+          "binding": {
+            "type": "zeebe:taskDefinition:type"
+          }
+        },
+        {
+          "label": "Method",
+          "group": "endpoint",
+          "type": "Dropdown",
+          "value": "get",
+          "choices": [
+            { "name": "GET", "value": "get" },
+            { "name": "POST", "value": "post" },
+            { "name": "PATCH", "value": "patch" },
+            { "name": "PUT", "value": "put" },
+            { "name": "DELETE", "value": "delete" }
+          ],
+          "binding": {
+            "type": "zeebe:input",
+            "name": "method"
+          }
+        },
+        {
+          "label": "URL",
+          "group": "endpoint",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "url"
+          },
+          "constraints": {
+            "notEmpty": true,
+            "pattern": {
+              "value": "^https?://.*",
+              "message": "Must be a http(s) URL."
+            }
+          }
+        },
+        {
+          "label": "Query Parameters",
+          "description": "Map of query parameters to add to the request URL",
+          "group": "endpoint",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "queryParameters"
+          },
+          "optional": true
+        },
+        {
+          "label": "HTTP Headers",
+          "description": "Map of HTTP headers to add to the request",
+          "group": "endpoint",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "headers"
+          },
+          "optional": true
+        },
+        {
+          "type": "Hidden",
+          "value": "basic",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "authentication.type"
+          }
+        },
+        {
+          "label": "Username",
+          "group": "authentication",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "authentication.username"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Password",
+          "group": "authentication",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "authentication.password"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Request Body",
+          "description": "JSON payload to send with the request",
+          "group": "input",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "body"
+          },
+          "optional": true
+        },
+        {
+          "label": "Result Variable",
+          "description": "Name of variable to store the response in",
+          "group": "output",
+          "type": "String",
+          "binding": {
+            "type": "zeebe:taskHeader",
+            "key": "resultVariable"
+          }
+        },
+        {
+          "label": "Result Expression",
+          "description": "Expression to map the response into process variables",
+          "group": "output",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:taskHeader",
+            "key": "resultExpression"
+          }
+        }
+      ]
+    },
+    {
+      "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+      "name": "REST Connector (Bearer Token Auth)",
+      "id": "io.camunda.connectors.HttpJson.v1.bearerToken",
+      "description": "Invoke REST API and retrieve the result secured by Bearer Token Authentication",
+      "documentationRef": "https://docs.camunda.io/docs/components/modeler/web-modeler/connectors/available-connectors/rest/",
+      "icon": {
+        "contents": "data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M17.0335%208.99997C17.0335%2013.4475%2013.4281%2017.0529%208.98065%2017.0529C4.53316%2017.0529%200.927765%2013.4475%200.927765%208.99997C0.927765%204.55248%204.53316%200.947083%208.98065%200.947083C13.4281%200.947083%2017.0335%204.55248%2017.0335%208.99997Z%22%20fill%3D%22%23505562%22%2F%3E%0A%3Cpath%20d%3D%22M4.93126%2014.1571L6.78106%203.71471H10.1375C11.1917%203.71471%2011.9824%203.98323%2012.5095%204.52027C13.0465%205.04736%2013.315%205.73358%2013.315%206.57892C13.315%207.44414%2013.0714%208.15522%2012.5841%208.71215C12.1067%209.25913%2011.4553%209.63705%2010.6298%209.8459L12.0619%2014.1571H10.3315L9.03364%2010.0249H7.24351L6.51254%2014.1571H4.93126ZM7.49711%208.59281H9.24248C9.99832%208.59281%2010.5901%208.42374%2011.0177%208.08561C11.4553%207.73753%2011.6741%207.26513%2011.6741%206.66842C11.6741%206.19106%2011.5249%205.81811%2011.2265%205.54959C10.9282%205.27113%2010.4558%205.1319%209.80936%205.1319H8.10874L7.49711%208.59281Z%22%20fill%3D%22white%22%2F%3E%0A%3C%2Fsvg%3E%0A"
+      },
+      "appliesTo": [
+        "bpmn:Task"
+      ],
+      "elementType": {
+        "value": "bpmn:ServiceTask"
+      },
+      "category": {
+        "id": "rest",
+        "name": "REST Connector"
+      },
+      "groups": [
+        {
+          "id": "endpoint",
+          "label": "HTTP Endpoint"
+        },
+        {
+          "id": "input",
+          "label": "Payload"
+        },
+        {
+          "id": "authentication",
+          "label": "Authentication"
+        },
+        {
+          "id": "output",
+          "label": "Response Mapping"
+        }
+      ],
+      "properties": [
+        {
+          "type": "Hidden",
+          "value": "io.camunda:http-json:1",
+          "binding": {
+            "type": "zeebe:taskDefinition:type"
+          }
+        },
+        {
+          "label": "Method",
+          "group": "endpoint",
+          "type": "Dropdown",
+          "value": "get",
+          "choices": [
+            { "name": "GET", "value": "get" },
+            { "name": "POST", "value": "post" },
+            { "name": "PATCH", "value": "patch" },
+            { "name": "PUT", "value": "put" },
+            { "name": "DELETE", "value": "delete" }
+          ],
+          "binding": {
+            "type": "zeebe:input",
+            "name": "method"
+          }
+        },
+        {
+          "label": "URL",
+          "group": "endpoint",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "url"
+          },
+          "constraints": {
+            "notEmpty": true,
+            "pattern": {
+              "value": "^https?://.*",
+              "message": "Must be a http(s) URL."
+            }
+          }
+        },
+        {
+          "label": "Query Parameters",
+          "description": "Map of query parameters to add to the request URL",
+          "group": "endpoint",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "queryParameters"
+          },
+          "optional": true
+        },
+        {
+          "label": "HTTP Headers",
+          "description": "Map of HTTP headers to add to the request",
+          "group": "endpoint",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "headers"
+          },
+          "optional": true
+        },
+        {
+          "type": "Hidden",
+          "value": "bearer",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "authentication.type"
+          }
+        },
+        {
+          "label": "Bearer Token",
+          "group": "authentication",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "authentication.token"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Request Body",
+          "description": "JSON payload to send with the request",
+          "group": "input",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "body"
+          },
+          "optional": true
+        },
+        {
+          "label": "Result Variable",
+          "description": "Name of variable to store the response in",
+          "group": "output",
+          "type": "String",
+          "binding": {
+            "type": "zeebe:taskHeader",
+            "key": "resultVariable"
+          }
+        },
+        {
+          "label": "Result Expression",
+          "description": "Expression to map the response into process variables",
+          "group": "output",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:taskHeader",
+            "key": "resultExpression"
+          }
+        }
+      ]
+    },
+    {
+      "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+      "name": "SendGrid Email Template Connector",
+      "id": "io.camunda.connectors.SendGrid.v1.template",
+      "description": "Send an Email via SendGrid Dynamic Template",
+      "documentationRef": "https://docs.camunda.io/docs/components/modeler/web-modeler/connectors/available-connectors/sendgrid/",
+      "icon": {
+        "contents": "data:image/svg+xml;utf8,%3Csvg%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M0.285706%205.40847H5.43837V10.5611H0.285706V5.40847Z%22%20fill%3D%22white%22%2F%3E%0A%3Cpath%20d%3D%22M0.285706%205.40847H5.43837V10.5611H0.285706V5.40847Z%22%20fill%3D%22%2399E1F4%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V15.6844H5.43837V10.5611Z%22%20fill%3D%22white%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V15.6844H5.43837V10.5611Z%22%20fill%3D%22%2399E1F4%22%2F%3E%0A%3Cpath%20d%3D%22M0.285706%2015.6846L5.43837%2015.6844V15.7143H0.285706V15.6846ZM0.285706%2010.5619H5.43837V15.6844L0.285706%2015.6846V10.5619Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%200.285706H10.5611V5.40847H5.43837V0.285706ZM10.5616%205.43837H15.7143V10.5611H10.5616V5.43837Z%22%20fill%3D%22%2300B3E3%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V5.40847H5.43837V10.5611Z%22%20fill%3D%22%23009DD9%22%2F%3E%0A%3Cpath%20d%3D%22M10.5611%200.285706H15.7143V5.40847H10.5611V0.285706Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3Cpath%20d%3D%22M10.5611%205.40847H15.7143V5.43837H10.5616L10.5611%205.40847Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3C%2Fsvg%3E"
+      },
+      "appliesTo": [
+        "bpmn:Task"
+      ],
+      "elementType": {
+        "value": "bpmn:ServiceTask"
+      },
+      "groups": [
+        {
+          "id": "sendgrid",
+          "label": "SendGrid API"
+        },
+        {
+          "id": "sender",
+          "label": "Sender"
+        },
+        {
+          "id": "receiver",
+          "label": "Receiver"
+        },
+        {
+          "id": "template",
+          "label": "Dynamic Email Template"
+        }
+      ],
+      "properties": [
+        {
+          "type": "Hidden",
+          "value": "io.camunda:sendgrid:1",
+          "binding": {
+            "type": "zeebe:taskDefinition:type"
+          }
+        },
+        {
+          "label": "SendGrid API Key",
+          "group": "sendgrid",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "apiKey"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Name",
+          "group": "sender",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "from.name"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Email Address",
+          "group": "sender",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "from.email"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Name",
+          "group": "receiver",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "to.name"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Email Address",
+          "group": "receiver",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "to.email"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Template ID",
+          "group": "template",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "template.id"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Template Data",
+          "group": "template",
+          "type": "Text",
+          "feel": "required",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "template.data"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        }
+      ]
+    },
+    {
+      "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+      "name": "SendGrid Email Connector",
+      "id": "io.camunda.connectors.SendGrid.v1.content",
+      "description": "Send an Email via SendGrid",
+      "documentationRef": "https://docs.camunda.io/docs/components/modeler/web-modeler/connectors/available-connectors/sendgrid/",
+      "icon": {
+        "contents": "data:image/svg+xml;utf8,%3Csvg%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M0.285706%205.40847H5.43837V10.5611H0.285706V5.40847Z%22%20fill%3D%22white%22%2F%3E%0A%3Cpath%20d%3D%22M0.285706%205.40847H5.43837V10.5611H0.285706V5.40847Z%22%20fill%3D%22%2399E1F4%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V15.6844H5.43837V10.5611Z%22%20fill%3D%22white%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V15.6844H5.43837V10.5611Z%22%20fill%3D%22%2399E1F4%22%2F%3E%0A%3Cpath%20d%3D%22M0.285706%2015.6846L5.43837%2015.6844V15.7143H0.285706V15.6846ZM0.285706%2010.5619H5.43837V15.6844L0.285706%2015.6846V10.5619Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%200.285706H10.5611V5.40847H5.43837V0.285706ZM10.5616%205.43837H15.7143V10.5611H10.5616V5.43837Z%22%20fill%3D%22%2300B3E3%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V5.40847H5.43837V10.5611Z%22%20fill%3D%22%23009DD9%22%2F%3E%0A%3Cpath%20d%3D%22M10.5611%200.285706H15.7143V5.40847H10.5611V0.285706Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3Cpath%20d%3D%22M10.5611%205.40847H15.7143V5.43837H10.5616L10.5611%205.40847Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3C%2Fsvg%3E"
+      },
+      "appliesTo": [
+        "bpmn:Task"
+      ],
+      "elementType": {
+        "value": "bpmn:ServiceTask"
+      },
+      "groups": [
+        {
+          "id": "sendgrid",
+          "label": "SendGrid API"
+        },
+        {
+          "id": "sender",
+          "label": "Sender"
+        },
+        {
+          "id": "receiver",
+          "label": "Receiver"
+        },
+        {
+          "id": "content",
+          "label": "Email Content"
+        }
+      ],
+      "properties": [
+        {
+          "type": "Hidden",
+          "value": "io.camunda:sendgrid:1",
+          "binding": {
+            "type": "zeebe:taskDefinition:type"
+          }
+        },
+        {
+          "label": "SendGrid API Key",
+          "group": "sendgrid",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "apiKey"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Name",
+          "group": "sender",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "from.name"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Email Address",
+          "group": "sender",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "from.email"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Name",
+          "group": "receiver",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "to.name"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Email Address",
+          "group": "receiver",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "to.email"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Subject",
+          "group": "content",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "content.subject"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Content Type",
+          "group": "content",
+          "type": "String",
+          "feel": "optional",
+          "value": "text/plain",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "content.type"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        },
+        {
+          "label": "Body",
+          "group": "content",
+          "type": "Text",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:input",
+            "name": "content.value"
+          },
+          "constraints": {
+            "notEmpty": true
+          }
+        }
+      ]
+    },
+    {
+      "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+      "name": "Special Transaction",
+      "id": "io.camunda.example.connectors.SpecialTransaction",
+      "description": "Tests Transation templating",
+      "icon": {
+        "contents": "data:image/svg+xml;utf8,%3Csvg%20width%3D%2218%22%20height%3D%2218%22%20viewBox%3D%220%200%2018%2018%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M17.0335%208.99997C17.0335%2013.4475%2013.4281%2017.0529%208.98065%2017.0529C4.53316%2017.0529%200.927765%2013.4475%200.927765%208.99997C0.927765%204.55248%204.53316%200.947083%208.98065%200.947083C13.4281%200.947083%2017.0335%204.55248%2017.0335%208.99997Z%22%20fill%3D%22%23505562%22%2F%3E%0A%3Cpath%20d%3D%22M4.93126%2014.1571L6.78106%203.71471H10.1375C11.1917%203.71471%2011.9824%203.98323%2012.5095%204.52027C13.0465%205.04736%2013.315%205.73358%2013.315%206.57892C13.315%207.44414%2013.0714%208.15522%2012.5841%208.71215C12.1067%209.25913%2011.4553%209.63705%2010.6298%209.8459L12.0619%2014.1571H10.3315L9.03364%2010.0249H7.24351L6.51254%2014.1571H4.93126ZM7.49711%208.59281H9.24248C9.99832%208.59281%2010.5901%208.42374%2011.0177%208.08561C11.4553%207.73753%2011.6741%207.26513%2011.6741%206.66842C11.6741%206.19106%2011.5249%205.81811%2011.2265%205.54959C10.9282%205.27113%2010.4558%205.1319%209.80936%205.1319H8.10874L7.49711%208.59281Z%22%20fill%3D%22white%22%2F%3E%0A%3C%2Fsvg%3E%0A"
+      },
+      "documentationRef": "https://docs.camunda.io/docs/components/modeler/web-modeler/connectors/available-connectors/rest/",
+      "appliesTo": [
+        "bpmn:SubProcess"
+      ],
+      "elementType": {
+        "value": "bpmn:Transaction"
+      },
+      "properties": [
+        {
+          "label": "Prop",
+          "type": "String",
+          "feel": "optional",
+          "binding": {
+            "type": "zeebe:property",
+            "name": "prop"
+          }
+        }
+      ]
+    }
+  ]

--- a/test/fixtures/simple.bpmn
+++ b/test/fixtures/simple.bpmn
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0uo7yqr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0-dev" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0uo7yqr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:properties>
-          <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#10;  &#34;startData&#34;: &#34;foobar&#34; &#10;}" />
+          <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#10;  &#34;startData&#34;: {&#10;    &#34;foobar&#34;: 15&#10;  }&#10;}" />
         </zeebe:properties>
+        <zeebe:ioMapping>
+          <zeebe:output source="=startData" target="mappedStartData" />
+        </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_16gvdav</bpmn:outgoing>
     </bpmn:startEvent>

--- a/test/spec/integration.spec.js
+++ b/test/spec/integration.spec.js
@@ -135,18 +135,43 @@ describe('Integration', function() {
 
     beforeEach(() => createModeler(simpleXML));
 
-    it('should supply variables to variableResolver', inject(async function(elementRegistry, variableResolver) {
+    it('should scope variables to element', inject(async function(elementRegistry, variableResolver) {
 
       // given
-      const task = elementRegistry.get('ServiceTask_1');
+      const process = elementRegistry.get('Process_1');
 
       // when
-      const variables = await variableResolver.getVariablesForElement(task);
+      const variables = await variableResolver.getProcessVariables(process);
 
       // then
       expect(variables).to.variableEqual([
-        { name: 'output', type: 'Number' },
-        { name: 'startData', type: 'String' }
+        { name: 'output', type: 'Number', scope: 'ServiceTask_1' },
+        { name: 'startData', type: 'Context', scope: 'StartEvent_1' },
+        { name: 'mappedStartData', type: 'Context', scope: 'Process_1' },
+      ]);
+    }));
+
+
+    it('should keep info through mappings', inject(async function(elementRegistry, variableResolver) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      // when
+      const variables = await variableResolver.getVariablesForElement(process);
+
+      // then
+      expect(variables).to.variableEqual([
+        {
+          name: 'mappedStartData',
+          type: 'Context',
+          entries: [
+            {
+              name: 'foobar',
+              type: 'Number'
+            }
+          ]
+        }
       ]);
     }));
 

--- a/test/spec/integration.spec.js
+++ b/test/spec/integration.spec.js
@@ -24,6 +24,8 @@ import Modeler from 'bpmn-js/lib/Modeler';
 import simpleXML from '../fixtures/simple.bpmn';
 import elementTemplatesXML from '../fixtures/elementTemplates.bpmn';
 import elementTemplates from '../fixtures/templates.json';
+import connectorTemplates from '../fixtures/connectors.json';
+
 
 import {
   bootstrapPropertiesPanel,
@@ -124,7 +126,7 @@ describe('Integration', function() {
           CloudElementTemplatesPropertiesProviderModule,
           ElementTemplateChooserModule
         ],
-        elementTemplates
+        elementTemplates: connectorTemplates
       });
 
     expect(result.error).to.not.exist;

--- a/test/spec/variableProvider.spec.js
+++ b/test/spec/variableProvider.spec.js
@@ -66,7 +66,6 @@ describe('variable-provider', function() {
 
     const element = createElementWithVariables(variables);
 
-
     // when
     const result = provider.getVariables(element);
 
@@ -116,6 +115,28 @@ describe('variable-provider', function() {
             info: 'null'
           }
         ]
+      }
+    ]);
+  });
+
+
+  it('should scope variables to element', function() {
+
+    // given
+    const variables = JSON.stringify({
+      string: 'string',
+    });
+
+    const element = createElementWithVariables(variables);
+
+    // when
+    const result = provider.getVariables(element);
+
+    // then
+    expect(result).to.variableEqual([
+      {
+        name: 'string',
+        scope: element.id
       }
     ]);
   });


### PR DESCRIPTION
Example data is only scoped to the element where it is defined. This prevents us from polluting global state, promotes explicit output mappings and works also when the mapping is done in the backend (connector use-case).

Cf. https://github.com/camunda/camunda-modeler/issues/3524#issuecomment-1493963940

New Behavior:
![NoMapping](https://user-images.githubusercontent.com/21984219/229471956-1df4b7e6-2044-4079-a540-b43a99df90f2.png)
![withMapping](https://user-images.githubusercontent.com/21984219/229471966-b8746d3b-d248-480e-8f44-0f9ff3b4b143.png)