### PR TITLE
fix: format JSON examples in info preview

### DIFF
--- a/lib/variableProvider/ExampleJsonProvider.js
+++ b/lib/variableProvider/ExampleJsonProvider.js
@@ -54,7 +54,7 @@ function toInternalFormat(data = {}) {
 
     const newElement = {
       name: key,
-      info: JSON.stringify(value)
+      info: JSON.stringify(value, null, 2)
     };
 
     if (Array.isArray(value)) {

--- a/test/spec/variableProvider.spec.js
+++ b/test/spec/variableProvider.spec.js
@@ -90,7 +90,7 @@ describe('variable-provider', function() {
       {
         name: 'object',
         type: 'Context',
-        info: '{"nested":null}',
+        info: '{\n  "nested": null\n}',
         entries: [
           {
             name: 'nested',
@@ -108,7 +108,7 @@ describe('variable-provider', function() {
         name: 'array',
         type: 'List',
         isList: true,
-        info: '[{"nested":null}]',
+        info: '[\n  {\n    "nested": null\n  }\n]',
         entries: [
           {
             name: 'nested',


### PR DESCRIPTION
related to https://github.com/bpmn-io/feel-editor/issues/37

for correct display, this depends on https://github.com/bpmn-io/feel-editor/pull/38 . As the feel-editor is not a direct dependency, this is already ready for review


![image](https://user-images.githubusercontent.com/21984219/233945744-b1d9c3dc-ab91-42f9-b9c5-53a9456a680c.png)
