### PR TITLE
revert(provider): scope variables to current element

### DIFF
--- a/lib/variableProvider/ExampleJsonProvider.js
+++ b/lib/variableProvider/ExampleJsonProvider.js
@@ -13,16 +13,7 @@ export class ExampleJsonProvider extends VariableProvider {
     }
 
     const parsedData = getVariablesFromString(data);
-
-    // Scope data to current element only
-    const result = parsedData.map(variable => {
-      return {
-        ...variable,
-        scope: element
-      };
-    });
-
-    return result;
+    return parsedData;
   }
 }
 

--- a/test/fixtures/simple.bpmn
+++ b/test/fixtures/simple.bpmn
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0uo7yqr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0uo7yqr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0-dev" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:properties>
-          <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#10;  &#34;startData&#34;: {&#10;    &#34;foobar&#34;: 15&#10;  }&#10;}" />
+          <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#10;  &#34;startData&#34;: &#34;foobar&#34; &#10;}" />
         </zeebe:properties>
-        <zeebe:ioMapping>
-          <zeebe:output source="=startData" target="mappedStartData" />
-        </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_16gvdav</bpmn:outgoing>
     </bpmn:startEvent>

--- a/test/spec/integration.spec.js
+++ b/test/spec/integration.spec.js
@@ -137,43 +137,18 @@ describe('Integration', function() {
 
     beforeEach(() => createModeler(simpleXML));
 
-    it('should scope variables to element', inject(async function(elementRegistry, variableResolver) {
+    it('should supply variables to variableResolver', inject(async function(elementRegistry, variableResolver) {
 
       // given
-      const process = elementRegistry.get('Process_1');
+      const task = elementRegistry.get('ServiceTask_1');
 
       // when
-      const variables = await variableResolver.getProcessVariables(process);
+      const variables = await variableResolver.getVariablesForElement(task);
 
       // then
       expect(variables).to.variableEqual([
-        { name: 'output', type: 'Number', scope: 'ServiceTask_1' },
-        { name: 'startData', type: 'Context', scope: 'StartEvent_1' },
-        { name: 'mappedStartData', type: 'Context', scope: 'Process_1' },
-      ]);
-    }));
-
-
-    it('should keep info through mappings', inject(async function(elementRegistry, variableResolver) {
-
-      // given
-      const process = elementRegistry.get('Process_1');
-
-      // when
-      const variables = await variableResolver.getVariablesForElement(process);
-
-      // then
-      expect(variables).to.variableEqual([
-        {
-          name: 'mappedStartData',
-          type: 'Context',
-          entries: [
-            {
-              name: 'foobar',
-              type: 'Number'
-            }
-          ]
-        }
+        { name: 'output', type: 'Number' },
+        { name: 'startData', type: 'String' }
       ]);
     }));
 

--- a/test/spec/variableProvider.spec.js
+++ b/test/spec/variableProvider.spec.js
@@ -120,28 +120,6 @@ describe('variable-provider', function() {
   });
 
 
-  it('should scope variables to element', function() {
-
-    // given
-    const variables = JSON.stringify({
-      string: 'string',
-    });
-
-    const element = createElementWithVariables(variables);
-
-    // when
-    const result = provider.getVariables(element);
-
-    // then
-    expect(result).to.variableEqual([
-      {
-        name: 'string',
-        scope: element.id
-      }
-    ]);
-  });
-
-
   it('should NOT break with malformed JSON', function() {
 
     // given


### PR DESCRIPTION
This was initially introduced to not suggest invalid data when used in connectors. However, we have discovered that this behavior is confusing to users and leads to less adoption.

Additionally, Connectors do not yet provide any data. Therefore, let's focus on a better user experience and revert back to engine behavior. Cf. https://camunda.slack.com/archives/GP70M0J6M/p1692259383298699

This reverts commit db4efee0c574e9b2b84c66c57a9bcedbc7b99522.

related to https://github.com/camunda/camunda-modeler/issues/3728