### PR TITLE
feat: use JSON editor instead of TextArea for 'Example data' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [`@camunda/example-data-properties-provider`](https://git
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.4.0
+
+* `FEAT`: use JSON editor instead of `TextArea` as 'Example data' property input ([#22](https://github.com/camunda/example-data-properties-provider/pull/22))
+* `DEPS`: update to `@bpmn-io/properties-panel@3.41.2`
+
 ## 1.3.0
 
 * `FEAT`: move description to tooltip ([#18](https://github.com/camunda/example-data-properties-provider/issues/18))

--- a/lib/propertiesPanel/DataPropertiesProvider.js
+++ b/lib/propertiesPanel/DataPropertiesProvider.js
@@ -1,9 +1,9 @@
 import {
   Group,
-  isTextAreaEntryEdited
+  isJsonEditorEntryEdited
 } from '@bpmn-io/properties-panel';
 
-import JSONDataProperty from './JSONDataProperty';
+import ExampleDataProperty from './ExampleDataProperty';
 
 const VERY_LOW_PRIORITY = 100;
 
@@ -35,8 +35,8 @@ export default class DataPropertiesProvider {
         entries: [
           {
             id: 'exampleJson',
-            component: JSONDataProperty,
-            isEdited: isTextAreaEntryEdited
+            component: ExampleDataProperty,
+            isEdited: isJsonEditorEntryEdited
           }
         ],
         component: Group

--- a/lib/propertiesPanel/ExampleDataProperty.js
+++ b/lib/propertiesPanel/ExampleDataProperty.js
@@ -1,9 +1,7 @@
 import { html } from 'htm/preact';
-import { TextAreaEntry } from '@bpmn-io/properties-panel';
+import { JsonEditorEntry } from '@bpmn-io/properties-panel';
 import { useService } from 'bpmn-js-properties-panel';
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
-import { isObject } from 'min-dash';
-
 import {
   getExampleJson,
   EXAMPLE_JSON_PROPERTY_NAME,
@@ -11,10 +9,10 @@ import {
 } from '../util/jsonDataUtil';
 
 /**
- * Allows to edit the example JSON data of a task in a TextArea. Stores the data
+ * Allows editing of example data in the JSON editor. Stores the data
  * in a zeebe:Property with the name specified in `exampleDataUtil`.
  */
-const JSONDataProperty = (props) => {
+const ExampleDataProperty = (props) => {
   const {
     element
   } = props;
@@ -92,24 +90,9 @@ const JSONDataProperty = (props) => {
     commandStack.execute('properties-panel.multi-command-executor', commands);
   };
 
-  const onValidate = (value) => {
-    if (!value) {
-      return;
-    }
-
-    try {
-      const parsed = JSON.parse(value);
-      if (!isObject(parsed)) {
-        return translate('Example data must be a JSON object literal.');
-      }
-    }
-    catch (e) {
-      return e.message;
-    }
-  };
-
-  return TextAreaEntry({
+  return JsonEditorEntry({
     element,
+    placeholder: '{ }',
     label: translate('Example output'),
     tooltip: html`
       An example of data produced by this element. <a href="https://docs.camunda.io/docs/components/modeler/data-handling/" target="_blank" rel="noopener" title=${ translate('Example Data documentation') }>
@@ -118,13 +101,11 @@ const JSONDataProperty = (props) => {
     id: 'exampleJson',
     getValue,
     setValue,
-    debounce,
-    validate: onValidate,
-    monospace: true
+    debounce
   });
 };
 
-export default JSONDataProperty;
+export default ExampleDataProperty;
 
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@bpmn-io/element-template-chooser": "^2.1.0",
         "@bpmn-io/properties-panel": "^3.41.2",
         "@bpmn-io/variable-resolver": "^3.0.0",
+        "@codemirror/view": "^6.28.1",
         "@testing-library/preact": "^3.2.4",
         "babel-loader": "^10.1.1",
         "babel-plugin-istanbul": "^7.0.1",
@@ -43,7 +44,7 @@
         "zeebe-bpmn-moddle": "^1.13.0"
       },
       "peerDependencies": {
-        "@bpmn-io/properties-panel": "*",
+        "@bpmn-io/properties-panel": ">=3.41.2",
         "@bpmn-io/variable-resolver": "*",
         "bpmn-js": "*",
         "bpmn-js-properties-panel": ">= 1"

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "lib"
   ],
   "peerDependencies": {
-    "@bpmn-io/properties-panel": "*",
+    "@bpmn-io/properties-panel": ">=3.41.2",
     "@bpmn-io/variable-resolver": "*",
     "bpmn-js": "*",
     "bpmn-js-properties-panel": ">= 1"
   },
   "devDependencies": {
-    "@bpmn-io/element-template-chooser": "^2.1.0",
     "@bpmn-io/properties-panel": "^3.41.2",
+    "@bpmn-io/element-template-chooser": "^2.1.0",
     "@bpmn-io/variable-resolver": "^3.0.0",
     "@testing-library/preact": "^3.2.4",
     "babel-loader": "^10.1.1",
@@ -37,6 +37,7 @@
     "camunda-bpmn-js-behaviors": "^1.14.1",
     "chai": "^6.2.2",
     "cross-env": "^10.1.0",
+    "@codemirror/view": "^6.28.1",
     "eslint": "^9.39.2",
     "eslint-plugin-bpmn-io": "^2.2.0",
     "karma": "^6.4.3",

--- a/test/TestHelper.js
+++ b/test/TestHelper.js
@@ -9,7 +9,7 @@ import {
 } from 'bpmn-js/test/helper';
 
 import Modeler from 'bpmn-js/lib/Modeler';
-import { act, fireEvent } from '@testing-library/preact';
+import { act } from '@testing-library/preact';
 
 
 let PROPERTIES_PANEL_CONTAINER;
@@ -89,10 +89,6 @@ export function insertCoreStyles() {
     require('bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css').default
   );
 
-}
-
-export function changeInput(input, value) {
-  fireEvent.input(input, { target: { value } });
 }
 
 

--- a/test/spec/propertiesPanel.spec.js
+++ b/test/spec/propertiesPanel.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import TestContainer from 'mocha-test-container-support';
 
-import { bootstrapPropertiesPanel, changeInput, inject } from '../TestHelper';
+import { bootstrapPropertiesPanel, inject } from '../TestHelper';
 
 import { BpmnPropertiesPanelModule } from 'bpmn-js-properties-panel';
 
@@ -24,6 +24,8 @@ import {
   query as domQuery,
   classes as domClasses
 } from 'min-dom';
+
+import { EditorView } from '@codemirror/view';
 
 import { getExampleJson, getZeebeProperty, EXAMPLE_JSON_PROPERTY_NAME } from '../../lib/util/jsonDataUtil';
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
@@ -73,12 +75,9 @@ describe('Properties Panel - Data Group', function() {
       selection.select(task);
     });
 
-    const exampleInput = domQuery('textarea[name=exampleJson]', container);
-
     // then
-    expect(exampleInput).to.exist;
-
-    expect(exampleInput.value).to.equal('{"foo": "bar"}');
+    const cmEditor = await waitForEditor(container);
+    expect(getEditorValue(cmEditor)).to.equal('{"foo": "bar"}');
   }));
 
 
@@ -90,14 +89,15 @@ describe('Properties Panel - Data Group', function() {
     await act(() => {
       selection.select(task);
     });
-    const exampleInput = domQuery('textarea[name=exampleJson]', container);
+
+    const cmEditor = await waitForEditor(container);
 
     // assume
-    expect(exampleInput.value).to.equal('');
+    expect(getEditorValue(cmEditor)).to.equal('');
 
     // when
     await act(() => {
-      changeInput(exampleInput, '{"foo": "bar"}');
+      setEditorValue(cmEditor, '{"foo": "bar"}');
     });
 
     // then
@@ -115,10 +115,11 @@ describe('Properties Panel - Data Group', function() {
     await act(() => {
       selection.select(task);
     });
-    const exampleInput = domQuery('textarea[name=exampleJson]', container);
+
+    const cmEditor = await waitForEditor(container);
 
     // assume
-    expect(exampleInput.value).to.equal('{"foo": "bar"}');
+    expect(getEditorValue(cmEditor)).to.equal('{"foo": "bar"}');
 
     // when
     const newValue = '{"foo": "bar", "bar": "baz"}';
@@ -151,15 +152,15 @@ describe('Properties Panel - Data Group', function() {
         selection.select(task);
       });
 
+      const cmEditor = await waitForEditor(container);
       const entry = domQuery('.bio-properties-panel-entry', container);
-      const exampleInput = domQuery('textarea[name=exampleJson]', container);
 
       // assume
       await expectInvalid(entry);
 
       // when
       await act(() => {
-        changeInput(exampleInput, '');
+        setEditorValue(cmEditor, '');
       });
 
       // then
@@ -176,15 +177,15 @@ describe('Properties Panel - Data Group', function() {
         selection.select(task);
       });
 
+      const cmEditor = await waitForEditor(container);
       const entry = domQuery('.bio-properties-panel-entry', container);
-      const exampleInput = domQuery('textarea[name=exampleJson]', container);
 
       // assume
       await expectInvalid(entry);
 
       // when
       await act(() => {
-        changeInput(exampleInput, '{"foo": "bar"}');
+        setEditorValue(cmEditor, '{"foo": "bar"}');
       });
 
       // then
@@ -201,15 +202,15 @@ describe('Properties Panel - Data Group', function() {
         selection.select(task);
       });
 
+      const cmEditor = await waitForEditor(container);
       const entry = domQuery('.bio-properties-panel-entry', container);
-      const exampleInput = domQuery('textarea[name=exampleJson]', container);
 
       // assume
       await expectValid(entry);
 
       // when
       await act(() => {
-        changeInput(exampleInput, '{"foo": ');
+        setEditorValue(cmEditor, '{"foo": ');
       });
 
       // then
@@ -228,15 +229,15 @@ describe('Properties Panel - Data Group', function() {
           selection.select(task);
         });
 
+        const cmEditor = await waitForEditor(container);
         const entry = domQuery('.bio-properties-panel-entry', container);
-        const exampleInput = domQuery('textarea[name=exampleJson]', container);
 
         // assume
         await expectValid(entry);
 
         // when
         await act(() => {
-          changeInput(exampleInput, value);
+          setEditorValue(cmEditor, value);
         });
 
         // then
@@ -253,6 +254,35 @@ describe('Properties Panel - Data Group', function() {
 
 
 // helpers //////////
+
+async function waitForEditor(container) {
+  let cmEditor;
+  await waitFor(() => {
+    cmEditor = domQuery('.cm-editor', container);
+    expect(cmEditor).to.exist;
+  });
+  return cmEditor;
+}
+
+function getEditorView(cmEditorElement) {
+  return EditorView.findFromDOM(cmEditorElement);
+}
+
+function getEditorValue(cmEditorElement) {
+  const view = getEditorView(cmEditorElement);
+  return view ? view.state.doc.toString() : '';
+}
+
+function setEditorValue(cmEditorElement, value) {
+  const view = getEditorView(cmEditorElement);
+  view.dispatch({
+    changes: {
+      from: 0,
+      to: view.state.doc.length,
+      insert: value
+    }
+  });
+}
 
 async function expectValid(node) {
   await waitFor(() => {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5855

### Proposed Changes

Use JSON editor instead of `TextArea` as 'Example data' property input

https://github.com/user-attachments/assets/0c26cd57-3d5d-473d-a7b0-ce54a2a48da4



### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
